### PR TITLE
Fix the version of pivotal-cf/brokerapi

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -225,6 +225,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b9e2a9475f02e5316d6a961948e8948d77fb379b0e296db40f1f82df978d71d7"
+  inputs-digest = "5f66968ec10e0d42b8a7a4a556fc9fdcb38dcc90bde5654ba7f72ded35a5a52c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,3 +9,7 @@
 [[constraint]]        
   name = "github.com/docker/docker"
   version = "1.13.1"
+
+[[constraint]]
+  name = "github.com/pivotal-cf/brokerapi"
+  version = "2.0.4"


### PR DESCRIPTION
 - add the brokerapi has a hard dependency in the Gopkg.toml


 
Running `dep ensure` should select the same version of the brokerapi that is vendored in.
