### PR TITLE
better error messaging when bad arguments

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,8 +66,10 @@ func NewState(configPath string, servicePath string) (*State, error) {
 		return nil, fmt.Errorf("Service Directory Missing")
 	}
 
-	if _, err := os.Stat(servicePath); os.IsNotExist(err) {
+	if mode, err := os.Stat(servicePath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("%v: %s", err, servicePath)
+	} else if !mode.IsDir() {
+		return nil, fmt.Errorf("A service directory is expected as the second argument.")
 	}
 
 	files, err := ioutil.ReadDir(servicePath)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -79,6 +79,14 @@ var _ = Describe("Config", func() {
 				})
 			})
 
+			Context("when service directory argument is not a directory", func() {
+				It("errors when services dir is missing", func() {
+					_, err := config.NewState(configPath, configPath)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("A service directory is expected as the second argument."))
+				})
+			})
+
 			Context("when service directory exists", func() {
 				BeforeEach(func() {
 					servicePath, err = ioutil.TempDir("", "service-dir")


### PR DESCRIPTION
- be explicit when the argument passed in for service directory is not a
directory


resolves #24