### PR TITLE
Deployer pulls geth port from containerInfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ test:
 
 dockertest:
 	docker build -f images/Dockerfile.test -t blockheads/tests .
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -it --rm blockheads/tests
+	docker run -v /var/run/docker.sock:/var/run/docker.sock --network host -it --rm blockheads/tests

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -44,7 +44,7 @@ func main() {
 		if err != nil {
 			logger.Fatal("could not set up a docker-client", err)
 		}
-		manager = docker.NewDockerContainerManager(logger, cli)
+		manager = docker.NewDockerContainerManager(logger, cli, state.Config.ExternalIP)
 		logger.Debug("using docker containermanager")
 	case "kubernetes":
 		config, err := rest.InClusterConfig()
@@ -61,7 +61,7 @@ func main() {
 		logger.Fatal("no container manager in config", fmt.Errorf("no container manager specified in config %q", configFilepath))
 	}
 
-	deployer := deployer.NewEthereumDeployer(logger, state.Config.DeployerPath)
+	deployer := deployer.NewEthereumDeployer(logger, state.Config.DeployerPath, state.Config.ExternalIP)
 	broker := broker.NewBlockheadBroker(logger, state, manager, deployer)
 	creds := brokerapi.BrokerCredentials{
 		Username: state.Config.Username,

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -61,7 +61,7 @@ func main() {
 		logger.Fatal("no container manager in config", fmt.Errorf("no container manager specified in config %q", configFilepath))
 	}
 
-	deployer := deployer.NewEthereumDeployer(logger, state.Config)
+	deployer := deployer.NewEthereumDeployer(logger, state.Config.DeployerPath)
 	broker := broker.NewBlockheadBroker(logger, state, manager, deployer)
 	creds := brokerapi.BrokerCredentials{
 		Username: state.Config.Username,

--- a/cmd/broker/main_test.go
+++ b/cmd/broker/main_test.go
@@ -352,7 +352,7 @@ func requestBind(client *http.Client, serviceId, planId, instanceId, bindingId s
 			ContractArgs []string `json:"contract_args"`
 		}{
 			ContractUrl:  "https://raw.githubusercontent.com/swetharepakula/hyperledger-fabric-evm-demo/blockhead_demo/poll.sol",
-			ContractArgs: []string{"1"},
+			ContractArgs: []string{"[1]"},
 		},
 	}
 

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
     "username":"a",
     "password":"b",
     "port": 3333,
-    "deployer_path":"",
+    "deployer_path":"pusher.js",
     "container_manager": "docker"
 }
 

--- a/pkg/config/assets/configs/test_config.json
+++ b/pkg/config/assets/configs/test_config.json
@@ -3,5 +3,6 @@
   "password": "password",
   "port": 3335,
   "container_manager":"docker",
-  "deployer_path": "/path/to/pusher.js"
+  "deployer_path": "/path/to/pusher.js",
+  "external_ip": "1.1.1.1"
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,7 +20,8 @@ type Config struct {
 	Username         string `json:"username,omitempty"`
 	Port             uint16 `json:"port"`
 	ContainerManager string `json:"container_manager,omitempty"`
-	DeployerPath     string `json:"deployer_path"`
+	DeployerPath     string `json:"deployer_path,omitempty"`
+	ExternalIP       string `json:"external_ip,omitempty"`
 }
 
 type Service struct {
@@ -68,6 +69,10 @@ func NewState(configPath string, servicePath string) (*State, error) {
 
 	if config.ContainerManager == "" {
 		config.ContainerManager = "docker"
+	}
+
+	if config.ExternalIP == "" {
+		config.ExternalIP = "127.0.0.1"
 	}
 
 	if servicePath == "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,6 +32,7 @@ var _ = Describe("Config", func() {
 					Port:             3335,
 					ContainerManager: "docker",
 					DeployerPath:     "/path/to/pusher.js",
+					ExternalIP:       "1.1.1.1",
 				}
 
 				Expect(err).NotTo(HaveOccurred())
@@ -62,6 +63,7 @@ var _ = Describe("Config", func() {
 					Port:             3333,
 					ContainerManager: "docker",
 					DeployerPath:     "/path/to/pusher.js/is/required",
+					ExternalIP:       "127.0.0.1",
 				}
 				Expect(state.Config).To(Equal(defaultConfig))
 			})

--- a/pkg/containermanager/docker/docker_manager.go
+++ b/pkg/containermanager/docker/docker_manager.go
@@ -19,14 +19,16 @@ type DockerClient interface {
 }
 
 type dockerContainerManager struct {
-	client DockerClient
-	logger lager.Logger
+	client     DockerClient
+	logger     lager.Logger
+	externalIP string
 }
 
-func NewDockerContainerManager(logger lager.Logger, client DockerClient) containermanager.ContainerManager {
+func NewDockerContainerManager(logger lager.Logger, client DockerClient, externalIP string) containermanager.ContainerManager {
 	return dockerContainerManager{
-		client: client,
-		logger: logger.Session("docker-container-manager"),
+		client:     client,
+		logger:     logger.Session("docker-container-manager"),
+		externalIP: externalIP,
 	}
 }
 
@@ -113,7 +115,7 @@ func (dc dockerContainerManager) Bind(ctx context.Context, bindingConfig contain
 	}
 
 	response := containermanager.ContainerInfo{
-		IP:       containerInfo.NetworkSettings.DefaultNetworkSettings.IPAddress,
+		IP:       dc.externalIP,
 		Bindings: bindings,
 	}
 

--- a/pkg/containermanager/docker/docker_manager_test.go
+++ b/pkg/containermanager/docker/docker_manager_test.go
@@ -25,7 +25,7 @@ var _ = Describe("DockerManager", func() {
 	BeforeEach(func() {
 		logger = lagertest.NewTestLogger("test")
 		client = &fakes.FakeDockerClient{}
-		manager = docker.NewDockerContainerManager(logger, client)
+		manager = docker.NewDockerContainerManager(logger, client, "host-ip")
 
 		containerConfig = containermanager.ContainerConfig{
 			Name:         "some-name",
@@ -144,7 +144,7 @@ var _ = Describe("DockerManager", func() {
 					},
 				}
 				expectedBindResponse = &containermanager.ContainerInfo{
-					IP:       "some-ip-address",
+					IP:       "host-ip",
 					Bindings: bindings,
 				}
 			})

--- a/pkg/deployer/assets/deployer_test.js
+++ b/pkg/deployer/assets/deployer_test.js
@@ -1,0 +1,78 @@
+args = process.argv
+
+// first arg is node
+// second arg is relative filepath of this file
+
+console.log("args "+ args)
+if (args[2] != "-c") {
+  console.log("Expected flag -c to be provided");
+  process.exit(1);
+}
+
+configFile = args[3]
+if (configFile == "") {
+  console.log("Deployer Config has not been provided");
+  process.exit(1);
+}
+var fs = require("fs");
+configContent = fs.readFileSync(configFile);
+var config = JSON.parse(configContent);
+
+if (config["provider"] != "http://127.0.0.1:1234") {
+  console.log("Incorrect provider. Expected http://127.0.0.1:1234, received " + config["provider"]);
+  process.exit(1);
+}
+
+if (config["password"] != "") {
+  console.log("Password should be empty");
+  process.exit(1);
+}
+
+contractArgs = config["args"]
+if (contractArgs.length != 2) {
+  console.log("Args were not passed in untouched");
+  process.exit(1);
+}
+
+if (contractArgs[0] != "sample-arg-1") {
+  console.log("Arg1 is in incorrect. Expected sample-arg-1, received " + contractArgs[0])
+  process.exit(1);
+}
+
+if (contractArgs[1] != "sample-arg-2") {
+  console.log("Arg2 is in incorrect. Expected sample-arg-2, received " + contractArgs[1])
+  process.exit(1);
+}
+
+
+if (args[4] != "-o") {
+  console.log("Expected flag -o to be provided");
+  process.exit(1);
+}
+
+outputFile = args[5]
+if (outputFile == "") {
+  console.log("Output file name has not been provided");
+  process.exit(1);
+}
+
+// hardcoded fake contract path for test
+if (args[6] != "path-to-contract") {
+  console.log("Incorrect contract path was passed in. Expected path-to-contract, received " + args[6]);
+  process.exit(1);
+}
+
+var fs = require('fs');
+var result = {};
+result["address"] = "sample-account";
+result["abi"] = "sample-abi";
+result["contract_address"] = "sample-address";
+result["gas_price"] = "0";
+result["transaction_hash"] = "sample-tx-hash";
+
+fs.writeFile(outputFile, JSON.stringify(result, null, 4), (err) => {
+  if (err) {
+    console.error("error writing file" + err);
+    process.exit(1)
+  };
+});

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -2,13 +2,13 @@ package deployer
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 
 	"code.cloudfoundry.org/lager"
-	"github.com/cloudfoundry-incubator/blockhead/pkg/config"
 	"github.com/cloudfoundry-incubator/blockhead/pkg/containermanager"
 	"github.com/pborman/uuid"
 )
@@ -20,11 +20,11 @@ type ContractInfo struct {
 }
 
 type NodeInfo struct {
-	Account          string `json:"address"`
-	Interface        string `json:"abi"`
-	ConctractAddress string `json:"contract_address"`
-	GasPrice         string `json:"gas_price"`
-	TransactionHash  string `json:"transaction_hash"`
+	Account         string `json:"address"`
+	Interface       string `json:"abi"`
+	ContractAddress string `json:"contract_address"`
+	GasPrice        string `json:"gas_price"`
+	TransactionHash string `json:"transaction_hash"`
 }
 
 //go:generate counterfeiter -o ../fakes/fake_deployer.go . Deployer
@@ -33,14 +33,14 @@ type Deployer interface {
 }
 
 type ethereumDeployer struct {
-	logger lager.Logger
-	config config.Config
+	logger       lager.Logger
+	deployerPath string
 }
 
-func NewEthereumDeployer(logger lager.Logger, config config.Config) Deployer {
+func NewEthereumDeployer(logger lager.Logger, deployerPath string) Deployer {
 	return &ethereumDeployer{
-		logger: logger,
-		config: config,
+		logger:       logger,
+		deployerPath: deployerPath,
 	}
 }
 
@@ -48,12 +48,17 @@ func (e ethereumDeployer) DeployContract(contractInfo *ContractInfo, containerIn
 	e.logger.Info("deploy-started")
 	defer e.logger.Info("deploy-finished")
 
+	// 8545 is the port we want from the geth node
+	portBindings := containerInfo.Bindings["8545"]
+	if len(portBindings) <= 0 {
+		return nil, errors.New("Port Bindings do not have 8545 port mapping")
+	}
 	config := struct {
 		Provider string   `json:"provider"`
 		Password string   `json:"password"`
 		Args     []string `json:"args"`
 	}{
-		Provider: fmt.Sprintf("http://%s:%s", containerInfo.IP, "8545"),
+		Provider: fmt.Sprintf("http://127.0.0.1:%s", portBindings[0].Port),
 		Password: "",
 		Args:     contractInfo.ContractArgs,
 	}
@@ -76,7 +81,7 @@ func (e ethereumDeployer) DeployContract(contractInfo *ContractInfo, containerIn
 	}
 	defer os.RemoveAll(outputFile.Name())
 
-	cmd := exec.Command("node", e.config.DeployerPath, "-c", configFile.Name(), "-o", outputFile.Name(), contractInfo.ContractPath)
+	cmd := exec.Command("node", e.deployerPath, "-c", configFile.Name(), "-o", outputFile.Name(), contractInfo.ContractPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		e.logger.Error("run-failed", err, lager.Data{"output": string(output)})

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -35,12 +35,14 @@ type Deployer interface {
 type ethereumDeployer struct {
 	logger       lager.Logger
 	deployerPath string
+	externalIP   string
 }
 
-func NewEthereumDeployer(logger lager.Logger, deployerPath string) Deployer {
+func NewEthereumDeployer(logger lager.Logger, deployerPath string, externalIP string) Deployer {
 	return &ethereumDeployer{
 		logger:       logger,
 		deployerPath: deployerPath,
+		externalIP:   externalIP,
 	}
 }
 
@@ -58,7 +60,7 @@ func (e ethereumDeployer) DeployContract(contractInfo *ContractInfo, containerIn
 		Password string   `json:"password"`
 		Args     []string `json:"args"`
 	}{
-		Provider: fmt.Sprintf("http://127.0.0.1:%s", portBindings[0].Port),
+		Provider: fmt.Sprintf("http://%s:%s", e.externalIP, portBindings[0].Port),
 		Password: "",
 		Args:     contractInfo.ContractArgs,
 	}

--- a/pkg/deployer/deployer_suite_test.go
+++ b/pkg/deployer/deployer_suite_test.go
@@ -1,0 +1,13 @@
+package deployer_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestDeployer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Deployer Suite")
+}

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Deployer", func() {
 
 	BeforeEach(func() {
 		logger = lagertest.NewTestLogger("test")
-		contractDeployer = deployer.NewEthereumDeployer(logger, filepath.Join("assets", "deployer_test.js"))
+		contractDeployer = deployer.NewEthereumDeployer(logger, filepath.Join("assets", "deployer_test.js"), "127.0.0.1")
 	})
 
 	It("runs the specified contract path", func() {

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -1,0 +1,55 @@
+package deployer_test
+
+import (
+	"path/filepath"
+
+	"code.cloudfoundry.org/lager/lagertest"
+	"github.com/cloudfoundry-incubator/blockhead/pkg/containermanager"
+	"github.com/cloudfoundry-incubator/blockhead/pkg/deployer"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Deployer", func() {
+	var (
+		contractDeployer deployer.Deployer
+		logger           *lagertest.TestLogger
+	)
+
+	BeforeEach(func() {
+		logger = lagertest.NewTestLogger("test")
+		contractDeployer = deployer.NewEthereumDeployer(logger, filepath.Join("assets", "deployer_test.js"))
+	})
+
+	It("runs the specified contract path", func() {
+		contractInfo := &deployer.ContractInfo{
+			ContractPath: "path-to-contract",
+			ContractArgs: []string{"sample-arg-1", "sample-arg-2"},
+		}
+
+		portBindings := make(map[string][]containermanager.Binding)
+		portBindings["8545"] = []containermanager.Binding{
+			containermanager.Binding{
+				HostIP: "12.34.56.78",
+				Port:   "1234",
+			},
+		}
+		containerInfo := &containermanager.ContainerInfo{
+			IP:       "12.34.56.78",
+			Bindings: portBindings,
+		}
+
+		nodeInfo, err := contractDeployer.DeployContract(contractInfo, containerInfo)
+		Expect(err).ToNot(HaveOccurred())
+
+		expectedNodeInfo := &deployer.NodeInfo{
+			Account:         "sample-account",
+			Interface:       "sample-abi",
+			ContractAddress: "sample-address",
+			GasPrice:        "0",
+			TransactionHash: "sample-tx-hash",
+		}
+
+		Expect(nodeInfo).To(Equal(expectedNodeInfo))
+	})
+})


### PR DESCRIPTION
 - Deployer pulls port for the geth node from the container info
 - change host to 127.0.0.1 to allow tests pass in test file
 - NewEthereumDeployer takes in deployer path instead of entire config
 - add deployer test with a fake deployer.js
 - fix bind tests to pass in correct contract constructor args



 - [x] have tests
 - [ ] get reviews
