### PR TITLE
Change app credentials

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -44,7 +44,7 @@ func main() {
 		if err != nil {
 			logger.Fatal("could not set up a docker-client", err)
 		}
-		manager = docker.NewDockerContainerManager(logger, cli, state.Config.ExternalIP)
+		manager = docker.NewDockerContainerManager(logger, cli, state.Config.ExternalAddress)
 		logger.Debug("using docker containermanager")
 	case "kubernetes":
 		config, err := rest.InClusterConfig()
@@ -61,7 +61,7 @@ func main() {
 		logger.Fatal("no container manager in config", fmt.Errorf("no container manager specified in config %q", configFilepath))
 	}
 
-	deployer := deployer.NewEthereumDeployer(logger, state.Config.DeployerPath, state.Config.ExternalIP)
+	deployer := deployer.NewEthereumDeployer(logger, state.Config.DeployerPath)
 	broker := broker.NewBlockheadBroker(logger, state, manager, deployer)
 	creds := brokerapi.BrokerCredentials{
 		Username: state.Config.Username,

--- a/cmd/broker/main_suite_test.go
+++ b/cmd/broker/main_suite_test.go
@@ -118,6 +118,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Port:             uint16(port),
 		DeployerPath:     filepath.Join(absPath, "pusher.js"),
 		ContainerManager: "docker",
+		ExternalAddress:  "127.0.0.1",
 	}
 	cfgBytes, err := json.Marshal(cfg)
 	_, err = f.Write(cfgBytes)

--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
     "password":"b",
     "port": 3333,
     "deployer_path":"pusher.js",
-    "container_manager": "docker"
+    "container_manager": "docker",
+    "external_address": "127.0.0.1"
 }
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -348,14 +348,14 @@ var _ = Describe("Broker", func() {
 						bindings := make(map[string][]containermanager.Binding)
 						bindings["1234"] = []containermanager.Binding{
 							containermanager.Binding{
-								HostIP: "some-host-ip",
-								Port:   "6789",
+								Port: "6789",
 							},
 						}
 
 						expectedContainerInfo = &containermanager.ContainerInfo{
-							IP:       "some-ip",
-							Bindings: bindings,
+							InternalAddress: "127.0.0.1",
+							ExternalAddress: "some-ip",
+							Bindings:        bindings,
 						}
 
 						nodeInfo := &deployer.NodeInfo{

--- a/pkg/config/assets/configs/required_config.json
+++ b/pkg/config/assets/configs/required_config.json
@@ -1,5 +1,6 @@
 {
   "username":"a-username-is-required",
   "password":"a-password-is-required",
-  "deployer_path":"/path/to/pusher.js/is/required"
+  "deployer_path":"/path/to/pusher.js/is/required",
+  "external_address":"127.0.0.1"
 }

--- a/pkg/config/assets/configs/test_config.json
+++ b/pkg/config/assets/configs/test_config.json
@@ -4,5 +4,5 @@
   "port": 3335,
   "container_manager":"docker",
   "deployer_path": "/path/to/pusher.js",
-  "external_ip": "1.1.1.1"
+  "external_address": "1.1.1.1"
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	Port             uint16 `json:"port"`
 	ContainerManager string `json:"container_manager,omitempty"`
 	DeployerPath     string `json:"deployer_path,omitempty"`
-	ExternalIP       string `json:"external_ip,omitempty"`
+	ExternalAddress  string `json:"external_address,omitempty"`
 }
 
 type Service struct {
@@ -67,12 +67,12 @@ func NewState(configPath string, servicePath string) (*State, error) {
 		return nil, fmt.Errorf("Deployer Path Missing from config")
 	}
 
-	if config.ContainerManager == "" {
-		config.ContainerManager = "docker"
+	if config.ExternalAddress == "" {
+		return nil, fmt.Errorf("External Address Missing from config")
 	}
 
-	if config.ExternalIP == "" {
-		config.ExternalIP = "127.0.0.1"
+	if config.ContainerManager == "" {
+		config.ContainerManager = "docker"
 	}
 
 	if servicePath == "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Config", func() {
 					Port:             3335,
 					ContainerManager: "docker",
 					DeployerPath:     "/path/to/pusher.js",
-					ExternalIP:       "1.1.1.1",
+					ExternalAddress:  "1.1.1.1",
 				}
 
 				Expect(err).NotTo(HaveOccurred())
@@ -63,7 +63,7 @@ var _ = Describe("Config", func() {
 					Port:             3333,
 					ContainerManager: "docker",
 					DeployerPath:     "/path/to/pusher.js/is/required",
-					ExternalIP:       "127.0.0.1",
+					ExternalAddress:  "127.0.0.1",
 				}
 				Expect(state.Config).To(Equal(defaultConfig))
 			})

--- a/pkg/containermanager/container_manager.go
+++ b/pkg/containermanager/container_manager.go
@@ -16,13 +16,13 @@ type BindConfig struct {
 }
 
 type Binding struct {
-	HostIP string
-	Port   string
+	Port string
 }
 
 type ContainerInfo struct {
-	IP       string
-	Bindings map[string][]Binding
+	ExternalAddress string
+	InternalAddress string
+	Bindings        map[string][]Binding
 }
 
 //go:generate counterfeiter -o ../fakes/fake_container_manager.go . ContainerManager

--- a/pkg/containermanager/docker/docker_manager.go
+++ b/pkg/containermanager/docker/docker_manager.go
@@ -19,16 +19,16 @@ type DockerClient interface {
 }
 
 type dockerContainerManager struct {
-	client     DockerClient
-	logger     lager.Logger
-	externalIP string
+	client          DockerClient
+	logger          lager.Logger
+	externalAddress string
 }
 
-func NewDockerContainerManager(logger lager.Logger, client DockerClient, externalIP string) containermanager.ContainerManager {
+func NewDockerContainerManager(logger lager.Logger, client DockerClient, externalAddress string) containermanager.ContainerManager {
 	return dockerContainerManager{
-		client:     client,
-		logger:     logger.Session("docker-container-manager"),
-		externalIP: externalIP,
+		client:          client,
+		logger:          logger.Session("docker-container-manager"),
+		externalAddress: externalAddress,
 	}
 }
 
@@ -107,16 +107,16 @@ func (dc dockerContainerManager) Bind(ctx context.Context, bindingConfig contain
 		containerBindings := []containermanager.Binding{}
 		for _, dockerBinding := range dockerBindings {
 			containerBindings = append(containerBindings, containermanager.Binding{
-				HostIP: dockerBinding.HostIP,
-				Port:   dockerBinding.HostPort,
+				Port: dockerBinding.HostPort,
 			})
 		}
 		bindings[port.Port()] = containerBindings
 	}
 
 	response := containermanager.ContainerInfo{
-		IP:       dc.externalIP,
-		Bindings: bindings,
+		InternalAddress: "127.0.0.1",
+		ExternalAddress: dc.externalAddress,
+		Bindings:        bindings,
 	}
 
 	return &response, nil

--- a/pkg/containermanager/docker/docker_manager_test.go
+++ b/pkg/containermanager/docker/docker_manager_test.go
@@ -139,13 +139,13 @@ var _ = Describe("DockerManager", func() {
 				bindings := make(map[string][]containermanager.Binding)
 				bindings["1234"] = []containermanager.Binding{
 					containermanager.Binding{
-						HostIP: "some-host-ip",
-						Port:   "6789",
+						Port: "6789",
 					},
 				}
 				expectedBindResponse = &containermanager.ContainerInfo{
-					IP:       "host-ip",
-					Bindings: bindings,
+					ExternalAddress: "host-ip",
+					InternalAddress: "127.0.0.1",
+					Bindings:        bindings,
 				}
 			})
 

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -35,14 +35,12 @@ type Deployer interface {
 type ethereumDeployer struct {
 	logger       lager.Logger
 	deployerPath string
-	externalIP   string
 }
 
-func NewEthereumDeployer(logger lager.Logger, deployerPath string, externalIP string) Deployer {
+func NewEthereumDeployer(logger lager.Logger, deployerPath string) Deployer {
 	return &ethereumDeployer{
 		logger:       logger,
 		deployerPath: deployerPath,
-		externalIP:   externalIP,
 	}
 }
 
@@ -60,7 +58,7 @@ func (e ethereumDeployer) DeployContract(contractInfo *ContractInfo, containerIn
 		Password string   `json:"password"`
 		Args     []string `json:"args"`
 	}{
-		Provider: fmt.Sprintf("http://%s:%s", e.externalIP, portBindings[0].Port),
+		Provider: fmt.Sprintf("http://%s:%s", containerInfo.InternalAddress, portBindings[0].Port),
 		Password: "",
 		Args:     contractInfo.ContractArgs,
 	}

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Deployer", func() {
 
 	BeforeEach(func() {
 		logger = lagertest.NewTestLogger("test")
-		contractDeployer = deployer.NewEthereumDeployer(logger, filepath.Join("assets", "deployer_test.js"), "127.0.0.1")
+		contractDeployer = deployer.NewEthereumDeployer(logger, filepath.Join("assets", "deployer_test.js"))
 	})
 
 	It("runs the specified contract path", func() {
@@ -30,13 +30,13 @@ var _ = Describe("Deployer", func() {
 		portBindings := make(map[string][]containermanager.Binding)
 		portBindings["8545"] = []containermanager.Binding{
 			containermanager.Binding{
-				HostIP: "12.34.56.78",
-				Port:   "1234",
+				Port: "1234",
 			},
 		}
 		containerInfo := &containermanager.ContainerInfo{
-			IP:       "12.34.56.78",
-			Bindings: portBindings,
+			InternalAddress: "127.0.0.1",
+			ExternalAddress: "12.34.56.78",
+			Bindings:        portBindings,
 		}
 
 		nodeInfo, err := contractDeployer.DeployContract(contractInfo, containerInfo)


### PR DESCRIPTION
 - change the format of app credentials to have more clarity
 - Port bindings will no longer include host ip
 - external address will be the recommended way to access the node
 - internal address is hardcoded to 127.0.0.1 for docker
 - change config parameter from `external_ip` to `external_address`

 - [x] have tests
 - [ ] get reviews
