### PR TITLE
add nodePort to DeployContract

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -158,7 +158,7 @@ func (b BlockheadBroker) Bind(ctx context.Context, instanceID, bindingID string,
 		return brokerapi.Binding{}, err
 	}
 
-	nodeInfo, err := b.deployer.DeployContract(contractInfo, containerInfo)
+	nodeInfo, err := b.deployer.DeployContract(contractInfo, containerInfo, plan.Ports[0])
 	if err != nil {
 		return brokerapi.Binding{}, err
 	}

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -386,9 +386,13 @@ var _ = Describe("Broker", func() {
 						_, err := blockhead.Bind(context.TODO(), "some-instance", "some-binding-id", bindDetails)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(fakeDeployer.DeployContractCallCount()).To(Equal(1))
-						fakeDeployer.DeployContractStub = func(contractInfo *deployer.ContractInfo, containerInfo *containermanager.ContainerInfo) (*deployer.NodeInfo, error) {
+
+						// testing the args for call inside the stub since we delete the
+						// contract file as part of the cleanup and after binding is done
+						fakeDeployer.DeployContractStub = func(contractInfo *deployer.ContractInfo, containerInfo *containermanager.ContainerInfo, nodePort string) (*deployer.NodeInfo, error) {
 							Expect(contractInfo.ContractPath).To(BeAnExistingFile())
 							Expect(containerInfo).To(Equal(expectedContainerInfo))
+							Expect(nodePort).To(Equal("1234"))
 							return nil, nil
 						}
 					})

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -29,7 +29,7 @@ type NodeInfo struct {
 
 //go:generate counterfeiter -o ../fakes/fake_deployer.go . Deployer
 type Deployer interface {
-	DeployContract(contractInfo *ContractInfo, containerInfo *containermanager.ContainerInfo) (*NodeInfo, error)
+	DeployContract(contractInfo *ContractInfo, containerInfo *containermanager.ContainerInfo, nodePort string) (*NodeInfo, error)
 }
 
 type ethereumDeployer struct {
@@ -44,14 +44,14 @@ func NewEthereumDeployer(logger lager.Logger, deployerPath string) Deployer {
 	}
 }
 
-func (e ethereumDeployer) DeployContract(contractInfo *ContractInfo, containerInfo *containermanager.ContainerInfo) (*NodeInfo, error) {
+func (e ethereumDeployer) DeployContract(contractInfo *ContractInfo, containerInfo *containermanager.ContainerInfo, nodePort string) (*NodeInfo, error) {
 	e.logger.Info("deploy-started")
 	defer e.logger.Info("deploy-finished")
 
-	// 8545 is the port we want from the geth node
-	portBindings := containerInfo.Bindings["8545"]
+	// nodePort is the port we want from the blockchain node
+	portBindings := containerInfo.Bindings[nodePort]
 	if len(portBindings) <= 0 {
-		return nil, errors.New("Port Bindings do not have 8545 port mapping")
+		return nil, errors.New(fmt.Sprintf("Port Bindings do not have %s port mapping", nodePort))
 	}
 	config := struct {
 		Provider string   `json:"provider"`

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -14,11 +14,13 @@ var _ = Describe("Deployer", func() {
 	var (
 		contractDeployer deployer.Deployer
 		logger           *lagertest.TestLogger
+		nodePort         string
 	)
 
 	BeforeEach(func() {
 		logger = lagertest.NewTestLogger("test")
 		contractDeployer = deployer.NewEthereumDeployer(logger, filepath.Join("assets", "deployer_test.js"))
+		nodePort = "8545"
 	})
 
 	It("runs the specified contract path", func() {
@@ -39,7 +41,7 @@ var _ = Describe("Deployer", func() {
 			Bindings:        portBindings,
 		}
 
-		nodeInfo, err := contractDeployer.DeployContract(contractInfo, containerInfo)
+		nodeInfo, err := contractDeployer.DeployContract(contractInfo, containerInfo, nodePort)
 		Expect(err).ToNot(HaveOccurred())
 
 		expectedNodeInfo := &deployer.NodeInfo{

--- a/pkg/fakes/fake_deployer.go
+++ b/pkg/fakes/fake_deployer.go
@@ -9,11 +9,12 @@ import (
 )
 
 type FakeDeployer struct {
-	DeployContractStub        func(contractInfo *deployer.ContractInfo, containerInfo *containermanager.ContainerInfo) (*deployer.NodeInfo, error)
+	DeployContractStub        func(contractInfo *deployer.ContractInfo, containerInfo *containermanager.ContainerInfo, nodePort string) (*deployer.NodeInfo, error)
 	deployContractMutex       sync.RWMutex
 	deployContractArgsForCall []struct {
 		contractInfo  *deployer.ContractInfo
 		containerInfo *containermanager.ContainerInfo
+		nodePort      string
 	}
 	deployContractReturns struct {
 		result1 *deployer.NodeInfo
@@ -27,17 +28,18 @@ type FakeDeployer struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeDeployer) DeployContract(contractInfo *deployer.ContractInfo, containerInfo *containermanager.ContainerInfo) (*deployer.NodeInfo, error) {
+func (fake *FakeDeployer) DeployContract(contractInfo *deployer.ContractInfo, containerInfo *containermanager.ContainerInfo, nodePort string) (*deployer.NodeInfo, error) {
 	fake.deployContractMutex.Lock()
 	ret, specificReturn := fake.deployContractReturnsOnCall[len(fake.deployContractArgsForCall)]
 	fake.deployContractArgsForCall = append(fake.deployContractArgsForCall, struct {
 		contractInfo  *deployer.ContractInfo
 		containerInfo *containermanager.ContainerInfo
-	}{contractInfo, containerInfo})
-	fake.recordInvocation("DeployContract", []interface{}{contractInfo, containerInfo})
+		nodePort      string
+	}{contractInfo, containerInfo, nodePort})
+	fake.recordInvocation("DeployContract", []interface{}{contractInfo, containerInfo, nodePort})
 	fake.deployContractMutex.Unlock()
 	if fake.DeployContractStub != nil {
-		return fake.DeployContractStub(contractInfo, containerInfo)
+		return fake.DeployContractStub(contractInfo, containerInfo, nodePort)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -51,10 +53,10 @@ func (fake *FakeDeployer) DeployContractCallCount() int {
 	return len(fake.deployContractArgsForCall)
 }
 
-func (fake *FakeDeployer) DeployContractArgsForCall(i int) (*deployer.ContractInfo, *containermanager.ContainerInfo) {
+func (fake *FakeDeployer) DeployContractArgsForCall(i int) (*deployer.ContractInfo, *containermanager.ContainerInfo, string) {
 	fake.deployContractMutex.RLock()
 	defer fake.deployContractMutex.RUnlock()
-	return fake.deployContractArgsForCall[i].contractInfo, fake.deployContractArgsForCall[i].containerInfo
+	return fake.deployContractArgsForCall[i].contractInfo, fake.deployContractArgsForCall[i].containerInfo, fake.deployContractArgsForCall[i].nodePort
 }
 
 func (fake *FakeDeployer) DeployContractReturns(result1 *deployer.NodeInfo, result2 error) {


### PR DESCRIPTION
- allows to determine from the service plan which port the blockchain node is listening on


 - [x] document your feature
 - [x] comment your code
 - [x] update the README / how-to-run
 - [x] have tests
 - [x] get reviews
