### PR TITLE
Fix config conversion of service defintions into state

### DIFF
--- a/pkg/config/assets/services/service_config_multiple_plans.json
+++ b/pkg/config/assets/services/service_config_multiple_plans.json
@@ -1,0 +1,27 @@
+{
+    "name": "name-2",
+    "description": "desc",
+    "tags": [
+        "ethereum",
+        "geth"
+    ],
+    "display_name": "display-name",
+    "plans": [
+        {
+            "name": "plan-name-2",
+            "image": "image",
+            "ports": [
+                "1234"
+            ],
+            "description": "plan-desc"
+        },
+        {
+            "name": "plan-name-3",
+            "image": "image-2",
+            "ports": [
+                "1234"
+            ],
+            "description": "plan-desc-2"
+        }
+    ]
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -124,7 +124,9 @@ func NewState(configPath string, servicePath string) (*State, error) {
 
 		for _, plan := range serviceDef.Plans {
 			id := uuid.New()
-			service.Plans[id] = &plan
+			//necessary to create a new variable so that a new pointer is created before storing the plan
+			p := plan
+			service.Plans[id] = &p
 		}
 
 		state.Services[serviceID] = &service

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -199,6 +199,52 @@ var _ = Describe("Config", func() {
 							))
 						})
 					})
+
+					Context("when there is service with multiple plans", func() {
+						var anotherExpectedService config.Service
+						BeforeEach(func() {
+							serviceFilePath = fmt.Sprintf("%s/service_config_multiple_plans.json", servicePath)
+							copy("assets/services/service_config_multiple_plans.json", serviceFilePath)
+
+							anotherExpectedService = config.Service{
+								Name:        "name-2",
+								Description: "desc",
+								DisplayName: "display-name",
+								Tags:        []string{"ethereum", "geth"},
+							}
+
+							planMap := make(map[string]*config.Plan)
+							expectedPlan1 := config.Plan{
+								Name:        "plan-name-2",
+								Image:       "image",
+								Ports:       []string{"1234"},
+								Description: "plan-desc",
+							}
+							planMap["uuid-4"] = &expectedPlan1
+
+							expectedPlan2 := config.Plan{
+								Name:        "plan-name-3",
+								Image:       "image-2",
+								Ports:       []string{"1234"},
+								Description: "plan-desc-2",
+							}
+							planMap["uuid-5"] = &expectedPlan2
+
+							anotherExpectedService.Plans = planMap
+							expectedServices["uuid-3"] = anotherExpectedService
+
+						})
+
+						It("should have the both plan in the second service", func() {
+							parsedState, err := config.NewState(configPath, servicePath)
+							Expect(err).NotTo(HaveOccurred())
+
+							Expect(parsedState.Services).To(ConsistOf(
+								utils.EquivalentService(&expectedService),
+								utils.EquivalentService(&anotherExpectedService),
+							))
+						})
+					})
 				})
 			})
 		})


### PR DESCRIPTION
 - Due to the plans pointer in the for loop, config would only take
 one plan per service and add it multiple times.
 - By creating a new plan object before adding it to the internal
memory of services

 - [x] comment your code
 - [ ] have tests
 - [ ] get reviews
